### PR TITLE
Copy start script into container on build

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,8 @@ FROM python:3.10.5-alpine3.15
 RUN pip install fastapi uvicorn environs psycopg2-binary sqlalchemy pytest requests
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
+COPY ./start.sh /start.sh
+RUN chmod +x /start.sh
 
-CMD ["./start.sh"]
+CMD ["/bin/sh", "-c", "/start.sh"]
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 
+cd /usr/src/app
 pip install -e .
 uvicorn catalog_app.main:app --reload --host 0.0.0.0 --port 8000


### PR DESCRIPTION
This is the try to fix a problem that @arnevogt has with starting the docker container for the backend.

This here will copy the start script in the build phase into the container and makes sure it is executable.
The start script will not be overwritten with the volume mount - so the chances are a little bit higher, that it will work then.

Implications: If there are changes on the start.sh script, you will have to rebuild the image.