### PR TITLE
Added file storage to docker compose

### DIFF
--- a/docker-compose-with-wrappers.yml
+++ b/docker-compose-with-wrappers.yml
@@ -17,6 +17,7 @@ services:
     networks:
       - db
       - queue
+      - filestorage
     environment:
       appID: 'deus-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.DeusWrapper'
@@ -31,6 +32,7 @@ services:
       wps.wpsUrl: 'https://rz-vm140.gfz-potsdam.de/wps/WebProcessingService'
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.DeusProcess'
+
   assetmaster_wrapper:
     image: spring-boot-image
     build:
@@ -43,6 +45,7 @@ services:
     networks:
       - db
       - queue
+      - filestorage
     environment:
       appID: 'assetmaster-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.AssetmasterWrapper'
@@ -57,6 +60,7 @@ services:
       wps.wpsUrl: 'https://rz-vm140.gfz-potsdam.de/wps/WebProcessingService'
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.AssetmasterProcess'
+
   modelprop_wrapper:
     image: spring-boot-image
     build:
@@ -69,6 +73,7 @@ services:
     networks:
       - db
       - queue
+      - filestorage
     environment:
       appID: 'modelprop-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ModelpropEqWrapper'
@@ -96,6 +101,7 @@ services:
     networks:
       - db
       - queue
+      - filestorage
     environment:
       appID: 'shakyground-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ShakygroundWrapper'
@@ -110,6 +116,7 @@ services:
       wps.wpsUrl: 'https://rz-vm140.gfz-potsdam.de/wps/WebProcessingService'
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ShakygroundProcess'
+
   quakeledger_wrapper:
     image: spring-boot-image
     build:
@@ -122,6 +129,7 @@ services:
     networks:
       - db
       - queue
+      - filestorage
     environment:
       appID: 'quakeledger-asyncwrapper'
       wrapperclass: 'org.n.riesgos.asyncwrapper.dummy.QuakeledgerWrapper'
@@ -149,6 +157,7 @@ services:
       - db
     networks:
       - db
+      - filestorage
     environment:
       ROOT_PATH: '/api/v1'
       SQLALCHEMY_DATABASE_URL: 'postgresql://postgres:postgres@db:5432/postgres'
@@ -189,11 +198,39 @@ services:
     volumes:
       - postgresdata:/var/lib/postgresql/data
 
+  filestorage:
+    image: minio/minio:RELEASE.2022-10-20T00-55-09Z
+    volumes:
+      - filestoragedata:/data
+    networks:
+      - filestorage
+    ports:
+      - 9000:9000
+      - 9090:9090
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: secretpassword
+    command: server /data --console-address ':9090'
+
+  filestorage_bucket_creation:
+    build:
+      context: 'filestorage/bucketcreation'
+    networks:
+      - filestorage
+    environment:
+      MINIO_ROOT_USER: admin
+      MINIO_ROOT_PASSWORD: secretpassword
+      MINIO_SERVER: filestorage
+      MINIO_PORT: 9000
+      MINIO_BUCKET_NAME: riesgosfiles
+
 volumes:
   postgresdata:
   pulsardata:
   pulsarconf:
+  filestoragedata:
 
 networks:
   db:
   queue:
+  filestorage:

--- a/filestorage/bucketcreation/Dockerfile
+++ b/filestorage/bucketcreation/Dockerfile
@@ -1,0 +1,4 @@
+FROM minio/mc:latest
+
+COPY entrypoint.sh /entrypoint.sh
+ENTRYPOINT /entrypoint.sh

--- a/filestorage/bucketcreation/entrypoint.sh
+++ b/filestorage/bucketcreation/entrypoint.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+
+# First we need to wait until we can talk with the server...
+until curl -f http://${MINIO_SERVER}:${MINIO_PORT}/minio/health/live
+do
+    echo "Waiting to connect to minio server..."
+    sleep 5
+done
+
+# Then we need to create an alias to work with the minio server
+/usr/bin/mc alias set minio http://${MINIO_SERVER}:${MINIO_PORT} ${MINIO_ROOT_USER} ${MINIO_ROOT_PASSWORD} --api S3v4
+# And then we can make the bucket & set its policy
+/usr/bin/mc mb --quiet minio/${MINIO_BUCKET_NAME}
+/usr/bin/mc policy set download minio/${MINIO_BUCKET_NAME}
+
+
+# If we would need to run for longer, we could run
+#
+# tail -f /dev/null
+#
+# Then we could maybe reuse the container for doing more with the
+# mc management command.
+#
+# But in most cases we don't need to, so we exit.
+exit 0


### PR DESCRIPTION
This pull requests adds the file storage container (minio) and a container to create the bucket.

I only touched the docker-compose file with the wrappers, as the wrapper will also need to interact (in some way) with the file storage itself.

For the moment I expose the 9000 (api endpoints) & 9090 (Management UI for administrative tasks) of the minio container. Later, however, we should be able to remove those, as the file download should be done via the backend.

For the moment I also didn't add the env variables for the wrappers. For the naming there I suggest not to use something minio specific, but more general (as the container is called `filestore` and not `minio`).