### PR TITLE
Add nginx to the docker compose

### DIFF
--- a/docker-compose-with-wrappers.yml
+++ b/docker-compose-with-wrappers.yml
@@ -151,8 +151,6 @@ services:
       context: backend
     volumes:
       - './backend:/usr/src/app'
-    ports:
-      - 8000:8000
     depends_on:
       - db
     networks:
@@ -175,7 +173,7 @@ services:
   queue:
     image: apachepulsar/pulsar-standalone
     ports:
-      - 80:80
+      - 8081:80
       - 8080:8080
       - 6650:6650
     networks:
@@ -205,7 +203,6 @@ services:
     networks:
       - filestorage
     ports:
-      - 9000:9000
       - 9090:9090
     environment:
       MINIO_ROOT_USER: admin
@@ -223,6 +220,17 @@ services:
       MINIO_SERVER: filestorage
       MINIO_PORT: 9000
       MINIO_BUCKET_NAME: riesgosfiles
+
+  reverse_proxy:
+    image: nginx:1.23.2-alpine
+    ports:
+      - 80:80
+    networks:
+      - filestorage
+    volumes:
+      - ./reverse_proxy/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./reverse_proxy/nginx.conf:/etc/nginx/nginx.conf:ro
+
 
 volumes:
   postgresdata:

--- a/reverse_proxy/default.conf
+++ b/reverse_proxy/default.conf
@@ -1,0 +1,37 @@
+server {
+    listen       80;
+    server_name  localhost;
+
+    #location / {
+    #    root   /usr/share/nginx/html;
+    #    index  index.html index.htm;
+    #}
+
+    #error_page  404              /404.html;
+
+    #error_page   500 502 503 504  /50x.html;
+    #location = /50x.html {
+    #    root   /usr/share/nginx/html;
+    #}
+
+    # It will look like a url of the backend ifself.
+    # So in case we need it we can make a /download/
+    # endpoint in the backend itself - and simply
+    # replace the usage of the file storage directly.
+    location /api/v1/files/ {
+        # We point to the bucket that we just created.
+        proxy_pass http://filestorage:9000/riesgosfiles/;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /api {
+        proxy_pass http://backend:8000;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Server $host;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/reverse_proxy/nginx.conf
+++ b/reverse_proxy/nginx.conf
@@ -1,0 +1,32 @@
+
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    #tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    gzip  on;
+
+    include /etc/nginx/conf.d/*.conf;
+}


### PR DESCRIPTION
This adds an nginx container (as reverse proxy) to the docker compose setup.

- it will run on port 80 (hope that is not a problem)
- the backend will no longer expose its port 8000 to the server - instead it works via the nginx on port 80
- the download endpoint for the riesgosfiles bucket will now be on /api/v1/files, so that it looks like it is going over the backend (but instead we use the minio container here directly for downloading the files)