### PR TITLE
docker compose: reading credentials from .env file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,7 @@ tools/pulsar_pub_sub/target
 # System files
 .DS_Store
 Thumbs.db
+
+
+# Secrets
+.env

--- a/docker-compose-uncert.yml
+++ b/docker-compose-uncert.yml
@@ -32,8 +32,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.DeusProcess'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 
@@ -64,8 +64,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.AssetmasterProcess'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 
@@ -96,8 +96,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ModelpropProcess'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 
@@ -128,8 +128,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ShakygroundProcess'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 
@@ -160,8 +160,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.shakemap_sampler'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 
@@ -192,8 +192,8 @@ services:
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.QuakeledgerProcess'
       filestorage.endpoint: http://138.246.225.182
-      filestorage.user: admin
-      filestorage.password: secretpassword
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://138.246.225.182/riesgosfiles/
 


### PR DESCRIPTION
This seems to be the simplest way of handling credentials:
 - write actual credentials in a `.env` file
 - docker (compose) will automatically look for such a file to substitute `${variable-name}` in docker(-compose) files
 - adding .env to .gitignore so that secrets cannot be accidentally shared.

Github [encrypted secrets](https://docs.github.com/en/actions/security-guides/encrypted-secrets) are something that is specific to github actions and as such mostly useful to us when we do CI. 

But until then I can't think of a simpler way to substitute credentials. Is this alright for everyone?