### PR TITLE
Set the user by env variables and remove registration api

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add python3-dev gcc libc-dev g++
 RUN /usr/local/bin/python -m pip install --upgrade pip
 
 
-RUN pip install fastapi uvicorn environs psycopg2-binary sqlalchemy pytest requests
+RUN pip install fastapi uvicorn psycopg2-binary sqlalchemy pytest requests httpx
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/backend/catalog_app/config.py
+++ b/backend/catalog_app/config.py
@@ -1,0 +1,11 @@
+from typing import Optional
+from pydantic import BaseSettings, Field
+
+
+class Config(BaseSettings):
+    root_path: str = Field(env="ROOT_PATH", default="/")
+    sqlalchemy_database_url: str = Field(
+        env="SQLALCHEMY_DATABASE_URL", default="sqlite:///./sql_app.db"
+    )
+    initial_user_email: Optional[str] = Field(env="BACKEND_USER_EMAIL")
+    initial_user_password: Optional[str] = Field(env="BACKEND_USER_PASSWORD")

--- a/backend/catalog_app/crud.py
+++ b/backend/catalog_app/crud.py
@@ -258,6 +258,12 @@ def create_user(db: Session, user: User):
     return user
 
 
+def update_user(db: Session, user: User):
+    db.add(user)
+    db.commit()
+    return user
+
+
 def create_order(db: Session, order: Order):
     db.add(order)
     db.commit()

--- a/backend/catalog_app/database.py
+++ b/backend/catalog_app/database.py
@@ -1,12 +1,10 @@
-from environs import Env
+from .config import Config
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
 
-env = Env()
-SQLALCHEMY_DATABASE_URL = env.str("SQLALCHEMY_DATABASE_URL", "sqlite:///./sql_app.db")
-
-engine = create_engine(SQLALCHEMY_DATABASE_URL)
+config = Config()
+engine = create_engine(config.sqlalchemy_database_url)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
 Base = declarative_base()

--- a/backend/catalog_app/main.py
+++ b/backend/catalog_app/main.py
@@ -1,20 +1,22 @@
 from typing import List
+from contextlib import contextmanager
 
-from environs import Env
 from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request
 from fastapi.middleware.cors import CORSMiddleware
 from sqlalchemy.orm import Session
 
-from . import crud, routers, schemas
+from . import crud, routers, schemas, models
+from .config import Config
 from .dependencies import get_db
 
-env = Env()
-ROOT_PATH = env.str("ROOT_PATH", "/")
+
+# Read with pydantic
+config = Config()
 
 app = FastAPI(
-    openapi_url=f"{ROOT_PATH}/openapi.json",
-    docs_url=f"{ROOT_PATH}/docs",
-    redoc_url=f"{ROOT_PATH}/redoc",
+    openapi_url=f"{config.root_path}/openapi.json",
+    docs_url=f"{config.root_path}/docs",
+    redoc_url=f"{config.root_path}/redoc",
 )
 
 app.add_middleware(
@@ -26,7 +28,7 @@ app.add_middleware(
 )
 
 
-prefix_router = APIRouter(prefix=ROOT_PATH)
+prefix_router = APIRouter(prefix=config.root_path)
 prefix_router.include_router(routers.bbox_input_router)
 prefix_router.include_router(routers.complex_input_router)
 prefix_router.include_router(routers.complex_input_as_value_router)
@@ -41,3 +43,23 @@ prefix_router.include_router(routers.product_router)
 prefix_router.include_router(routers.product_type_router)
 prefix_router.include_router(routers.user_router)
 app.include_router(prefix_router)
+
+
+@app.on_event("startup")
+def insert_initial_user():
+    with contextmanager(get_db)() as db:
+        if config.initial_user_email and config.initial_user_password:
+            password_hash = models.User.generate_new_password_hash(
+                config.initial_user_password
+            )
+            existing_user = crud.get_user_by_email(db, config.initial_user_email)
+            if existing_user:
+                existing_user.password_hash = password_hash
+                crud.update_user(db, existing_user)
+            else:
+                new_user = models.User(
+                    email=config.initial_user_email,
+                    password_hash=password_hash,
+                    apikey=models.User.generate_new_apikey(),
+                )
+                crud.create_user(db, new_user)

--- a/backend/tests/base.py
+++ b/backend/tests/base.py
@@ -5,7 +5,7 @@ from sqlalchemy.orm import sessionmaker
 
 from catalog_app.database import Base
 from catalog_app.dependencies import get_db
-from catalog_app.main import ROOT_PATH, app
+from catalog_app.main import app
 
 SQLALCHEMY_DATABASE_URL = "sqlite:///./test.db"
 

--- a/backend/tests/test_routes/test_bbox_inputs.py
+++ b/backend/tests/test_routes/test_bbox_inputs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import BboxInput, Job, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_bbox_input_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/bbox-inputs")
+    response = client.get(f"{config.root_path}/bbox-inputs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -26,7 +26,7 @@ def test_read_bbox_input_list_one(session, client):
     )
     session.add_all([process, job, bbox_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/bbox-inputs")
+    response = client.get(f"{config.root_path}/bbox-inputs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -67,7 +67,7 @@ def test_read_bbox_input_list_filter_wps_identifier(session, client):
     )
     session.add_all([process, job, bbox_input1, bbox_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/bbox-inputs?wps_identifier=bbox2")
+    response = client.get(f"{config.root_path}/bbox-inputs?wps_identifier=bbox2")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -110,7 +110,7 @@ def test_read_bbox_input_list_filter_process_id(session, client):
     )
     session.add_all([process1, process2, job1, job2, bbox_input1, bbox_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/bbox-inputs?process_id={process2.id}")
+    response = client.get(f"{config.root_path}/bbox-inputs?process_id={process2.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -152,7 +152,7 @@ def test_read_bbox_input_list_filter_job_id(session, client):
     )
     session.add_all([process, job1, job2, bbox_input1, bbox_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/bbox-inputs?job_id={job2.id}")
+    response = client.get(f"{config.root_path}/bbox-inputs?job_id={job2.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -190,11 +190,11 @@ def test_read_bbox_input_list_101(session, client):
         session.add(bbox_input)
         session.commit()
     # In the first page we have 100 bbox inputs.
-    response = client.get(f"{ROOT_PATH}/bbox-inputs")
+    response = client.get(f"{config.root_path}/bbox-inputs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/bbox-inputs?skip=100")
+    response2 = client.get(f"{config.root_path}/bbox-inputs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -215,7 +215,7 @@ def test_read_bbox_input_detail_one(session, client):
     )
     session.add_all([process, job, bbox_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/bbox-inputs/{bbox_input.id}")
+    response = client.get(f"{config.root_path}/bbox-inputs/{bbox_input.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": bbox_input.id,
@@ -230,5 +230,5 @@ def test_read_bbox_input_detail_one(session, client):
 
 
 def test_read_bbox_input_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/bbox-inputs/-123")
+    response = client.get(f"{config.root_path}/bbox-inputs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_complex_inputs.py
+++ b/backend/tests/test_routes/test_complex_inputs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import ComplexInput, Job, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_complex_input_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/complex-inputs")
+    response = client.get(f"{config.root_path}/complex-inputs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -25,7 +25,7 @@ def test_read_complex_input_list_one(session, client):
     )
     session.add_all([process, job, complex_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs")
+    response = client.get(f"{config.root_path}/complex-inputs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -63,7 +63,7 @@ def test_read_complex_input_list_filter_wps_identifier(session, client):
     )
     session.add_all([process, job, complex_input1, complex_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs?wps_identifier=shakemap1")
+    response = client.get(f"{config.root_path}/complex-inputs?wps_identifier=shakemap1")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -102,7 +102,7 @@ def test_read_complex_input_list_filter_job_id(session, client):
     )
     session.add_all([process, job1, job2, complex_input1, complex_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs?job_id={job2.id}")
+    response = client.get(f"{config.root_path}/complex-inputs?job_id={job2.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -145,7 +145,7 @@ def test_read_complex_input_list_filter_process_id(session, client):
     )
     session.add_all([process1, process2, job1, job2, complex_input1, complex_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs?process_id={process2.id}")
+    response = client.get(f"{config.root_path}/complex-inputs?process_id={process2.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -181,11 +181,11 @@ def test_read_complex_input_list_101(session, client):
         session.add(complex_input)
         session.commit()
     # In the first page we have 100 complex inputs.
-    response = client.get(f"{ROOT_PATH}/complex-inputs")
+    response = client.get(f"{config.root_path}/complex-inputs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/complex-inputs?skip=100")
+    response2 = client.get(f"{config.root_path}/complex-inputs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -205,7 +205,7 @@ def test_read_complex_input_detail_one(session, client):
     )
     session.add_all([process, job, complex_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs/{complex_input.id}")
+    response = client.get(f"{config.root_path}/complex-inputs/{complex_input.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": complex_input.id,
@@ -219,5 +219,5 @@ def test_read_complex_input_detail_one(session, client):
 
 
 def test_read_complex_input_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/complex-inputs/-123")
+    response = client.get(f"{config.root_path}/complex-inputs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_complex_inputs_as_values.py
+++ b/backend/tests/test_routes/test_complex_inputs_as_values.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import ComplexInputAsValue, Job, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_complex_input_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values")
+    response = client.get(f"{config.root_path}/complex-inputs-as-values")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -25,7 +25,7 @@ def test_read_complex_input_list_one(session, client):
     )
     session.add_all([process, job, complex_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values")
+    response = client.get(f"{config.root_path}/complex-inputs-as-values")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -64,7 +64,7 @@ def test_read_complex_input_list_filter_wps_identifier(session, client):
     session.add_all([process, job, complex_input1, complex_input2])
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/complex-inputs-as-values?wps_identifier=shakemap1"
+        f"{config.root_path}/complex-inputs-as-values?wps_identifier=shakemap1"
     )
     assert response.status_code == 200
     assert response.json() == [
@@ -104,7 +104,9 @@ def test_read_complex_input_list_filter_job_id(session, client):
     )
     session.add_all([process, job1, job2, complex_input1, complex_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values?job_id={job2.id}")
+    response = client.get(
+        f"{config.root_path}/complex-inputs-as-values?job_id={job2.id}"
+    )
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -145,7 +147,7 @@ def test_read_complex_input_list_filter_process_id(session, client):
     session.add_all([process1, process2, job1, job2, complex_input1, complex_input2])
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/complex-inputs-as-values?process_id={process2.id}"
+        f"{config.root_path}/complex-inputs-as-values?process_id={process2.id}"
     )
     assert response.status_code == 200
     assert response.json() == [
@@ -182,11 +184,11 @@ def test_read_complex_input_list_101(session, client):
         session.add(complex_input)
         session.commit()
     # In the first page we have 100 complex inputs.
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values")
+    response = client.get(f"{config.root_path}/complex-inputs-as-values")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/complex-inputs-as-values?skip=100")
+    response2 = client.get(f"{config.root_path}/complex-inputs-as-values?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -206,7 +208,9 @@ def test_read_complex_input_detail_one(session, client):
     )
     session.add_all([process, job, complex_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values/{complex_input.id}")
+    response = client.get(
+        f"{config.root_path}/complex-inputs-as-values/{complex_input.id}"
+    )
     assert response.status_code == 200
     assert response.json() == {
         "id": complex_input.id,
@@ -220,5 +224,5 @@ def test_read_complex_input_detail_one(session, client):
 
 
 def test_read_complex_input_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/complex-inputs-as-values/-123")
+    response = client.get(f"{config.root_path}/complex-inputs-as-values/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_complex_outputs.py
+++ b/backend/tests/test_routes/test_complex_outputs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import ComplexOutput, Job, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_complex_output_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/complex-outputs")
+    response = client.get(f"{config.root_path}/complex-outputs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -25,7 +25,7 @@ def test_read_complex_output_list_one(session, client):
     )
     session.add_all([process, job, complex_output])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs")
+    response = client.get(f"{config.root_path}/complex-outputs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -63,7 +63,9 @@ def test_read_complex_output_list_filter_wps_identifier(session, client):
     )
     session.add_all([process, job, complex_output1, complex_output2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs?wps_identifier=shakemap1")
+    response = client.get(
+        f"{config.root_path}/complex-outputs?wps_identifier=shakemap1"
+    )
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -102,7 +104,7 @@ def test_read_complex_output_list_filter_job_id(session, client):
     )
     session.add_all([process, job1, job2, complex_output1, complex_output2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs?job_id={job1.id}")
+    response = client.get(f"{config.root_path}/complex-outputs?job_id={job1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -142,7 +144,9 @@ def test_read_complex_output_list_filter_process_id(session, client):
     )
     session.add_all([process1, process2, job1, job2, complex_output1, complex_output2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs?process_id={process1.id}")
+    response = client.get(
+        f"{config.root_path}/complex-outputs?process_id={process1.id}"
+    )
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -182,7 +186,7 @@ def test_read_complex_output_list_filter_mime_type(session, client):
     )
     session.add_all([process1, process2, job1, job2, complex_output1, complex_output2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs?mime_type=abc")
+    response = client.get(f"{config.root_path}/complex-outputs?mime_type=abc")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -218,11 +222,11 @@ def test_read_complex_output_list_101(session, client):
         session.add(complex_output)
         session.commit()
     # In the first page we have 100 complex outputs.
-    response = client.get(f"{ROOT_PATH}/complex-outputs")
+    response = client.get(f"{config.root_path}/complex-outputs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/complex-outputs?skip=100")
+    response2 = client.get(f"{config.root_path}/complex-outputs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -242,7 +246,7 @@ def test_read_complex_output_detail_one(session, client):
     )
     session.add_all([process, job, complex_output])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs/{complex_output.id}")
+    response = client.get(f"{config.root_path}/complex-outputs/{complex_output.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": complex_output.id,
@@ -256,5 +260,5 @@ def test_read_complex_output_detail_one(session, client):
 
 
 def test_read_complex_output_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/complex-outputs/-123")
+    response = client.get(f"{config.root_path}/complex-outputs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_complex_outputs_as_inputs.py
+++ b/backend/tests/test_routes/test_complex_outputs_as_inputs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import ComplexOutput, ComplexOutputAsInput, Job, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_complex_output_as_input_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs")
+    response = client.get(f"{config.root_path}/complex-outputs-as-inputs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -28,7 +28,7 @@ def test_read_complex_output_as_input_list_one(session, client):
     )
     session.add_all([process, job, complex_output, complex_output_as_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs")
+    response = client.get(f"{config.root_path}/complex-outputs-as-inputs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -70,7 +70,7 @@ def test_read_complex_output_as_input_list_filter_wps_identifier(session, client
     )
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/complex-outputs-as-inputs?wps_identifier=intensity1"
+        f"{config.root_path}/complex-outputs-as-inputs?wps_identifier=intensity1"
     )
     assert response.status_code == 200
     assert response.json() == [
@@ -114,7 +114,9 @@ def test_read_complex_output_as_input_list_filter_job_id(session, client):
         ]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs?job_id={job1.id}")
+    response = client.get(
+        f"{config.root_path}/complex-outputs-as-inputs?job_id={job1.id}"
+    )
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -160,7 +162,7 @@ def test_read_complex_output_as_input_list_filter_process_id(session, client):
     )
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/complex-outputs-as-inputs?process_id={process1.id}"
+        f"{config.root_path}/complex-outputs-as-inputs?process_id={process1.id}"
     )
     assert response.status_code == 200
     assert response.json() == [
@@ -197,11 +199,11 @@ def test_read_complex_output_as_input_list_101(session, client):
         session.add(complex_output_as_input)
         session.commit()
     # In the first page we have 100 complex outputs.
-    response = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs")
+    response = client.get(f"{config.root_path}/complex-outputs-as-inputs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs?skip=100")
+    response2 = client.get(f"{config.root_path}/complex-outputs-as-inputs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -225,7 +227,7 @@ def test_read_complex_output_as_input_detail_one(session, client):
     session.add_all([process, job, complex_output, complex_output_as_input])
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/complex-outputs-as-inputs/{complex_output_as_input.id}"
+        f"{config.root_path}/complex-outputs-as-inputs/{complex_output_as_input.id}"
     )
     assert response.status_code == 200
     assert response.json() == {
@@ -237,5 +239,5 @@ def test_read_complex_output_as_input_detail_one(session, client):
 
 
 def test_read_complex_output_as_input_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/complex-outputs-as-inputs/-123")
+    response = client.get(f"{config.root_path}/complex-outputs-as-inputs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_jobs.py
+++ b/backend/tests/test_routes/test_jobs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Job, Order, OrderJobRef, Process, User
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_job_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/jobs")
+    response = client.get(f"{config.root_path}/jobs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -17,7 +17,7 @@ def test_read_job_list_one(session, client):
     job = Job(process=process, status="pending")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/jobs")
+    response = client.get(f"{config.root_path}/jobs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -37,7 +37,7 @@ def test_read_job_list_filter_process_id(session, client):
     job2 = Job(process=process2, status="pending")
     session.add_all([process1, process2, job1, job2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/jobs?process_id={process1.id}")
+    response = client.get(f"{config.root_path}/jobs?process_id={process1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -56,7 +56,7 @@ def test_read_job_list_filter_status(session, client):
     job2 = Job(process=process1, status="pending")
     session.add_all([process1, job1, job2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/jobs?status=running")
+    response = client.get(f"{config.root_path}/jobs?status=running")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -82,7 +82,7 @@ def test_read_job_list_filter_order_id(session, client):
         [user, order1, order2, process1, job1, job2, order_job_ref1, order_job_ref2]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/jobs?order_id={order1.id}")
+    response = client.get(f"{config.root_path}/jobs?order_id={order1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -106,11 +106,11 @@ def test_read_job_list_101(session, client):
         session.add(job)
         session.commit()
     # In the first page we have 100 jobs.
-    response = client.get(f"{ROOT_PATH}/jobs")
+    response = client.get(f"{config.root_path}/jobs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/jobs?skip=100")
+    response2 = client.get(f"{config.root_path}/jobs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -122,7 +122,7 @@ def test_read_job_detail_one(session, client):
     job = Job(process=process, status="pending")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/jobs/{job.id}")
+    response = client.get(f"{config.root_path}/jobs/{job.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": job.id,
@@ -132,5 +132,5 @@ def test_read_job_detail_one(session, client):
 
 
 def test_read_job_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/jobs/-123")
+    response = client.get(f"{config.root_path}/jobs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_literal_inputs.py
+++ b/backend/tests/test_routes/test_literal_inputs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Job, LiteralInput, Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_literal_input_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/literal-inputs")
+    response = client.get(f"{config.root_path}/literal-inputs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -20,7 +20,7 @@ def test_read_literal_input_list_one(session, client):
     )
     session.add_all([process, job, literal_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/literal-inputs")
+    response = client.get(f"{config.root_path}/literal-inputs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -43,7 +43,7 @@ def test_read_literal_input_list_filter_wps_identifier(session, client):
     literal_input2 = LiteralInput(job=job, wps_identifier="vsgrid", input_value="usgs")
     session.add_all([process, job, literal_input1, literal_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/literal-inputs?wps_identifier=gmpe")
+    response = client.get(f"{config.root_path}/literal-inputs?wps_identifier=gmpe")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -67,7 +67,7 @@ def test_read_literal_input_list_filter_job_id(session, client):
     literal_input2 = LiteralInput(job=job2, wps_identifier="vsgrid", input_value="usgs")
     session.add_all([process, job1, job2, literal_input1, literal_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/literal-inputs?job_id={job1.id}")
+    response = client.get(f"{config.root_path}/literal-inputs?job_id={job1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -92,7 +92,7 @@ def test_read_literal_input_list_filter_process_id(session, client):
     literal_input2 = LiteralInput(job=job2, wps_identifier="vsgrid", input_value="usgs")
     session.add_all([process1, process2, job1, job2, literal_input1, literal_input2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/literal-inputs?process_id={process1.id}")
+    response = client.get(f"{config.root_path}/literal-inputs?process_id={process1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -122,11 +122,11 @@ def test_read_literal_input_list_101(session, client):
         session.add(literal_input)
         session.commit()
     # In the first page we have 100 literal inputs.
-    response = client.get(f"{ROOT_PATH}/literal-inputs")
+    response = client.get(f"{config.root_path}/literal-inputs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/literal-inputs?skip=100")
+    response2 = client.get(f"{config.root_path}/literal-inputs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -143,7 +143,7 @@ def test_read_literal_input_detail_one(session, client):
     )
     session.add_all([process, job, literal_input])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/literal-inputs/{literal_input.id}")
+    response = client.get(f"{config.root_path}/literal-inputs/{literal_input.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": literal_input.id,
@@ -154,5 +154,5 @@ def test_read_literal_input_detail_one(session, client):
 
 
 def test_read_literal_input_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/literal-inputs/-123")
+    response = client.get(f"{config.root_path}/literal-inputs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_order_job_refs.py
+++ b/backend/tests/test_routes/test_order_job_refs.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Job, Order, OrderJobRef, Process, User
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_order_job_ref_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/order-job-refs")
+    response = client.get(f"{config.root_path}/order-job-refs")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -20,7 +20,7 @@ def test_read_order_job_ref_list_one(session, client):
     order_job_ref = OrderJobRef(order=order, job=job)
     session.add_all([user, order, process, job, order_job_ref])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/order-job-refs")
+    response = client.get(f"{config.root_path}/order-job-refs")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -43,7 +43,7 @@ def test_read_order_job_ref_list_filter_job_id(session, client):
     order_job_ref2 = OrderJobRef(order=order, job=job2)
     session.add_all([user, order, process, job1, job2, order_job_ref1, order_job_ref2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/order-job-refs?job_id={job1.id}")
+    response = client.get(f"{config.root_path}/order-job-refs?job_id={job1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -68,7 +68,7 @@ def test_read_order_job_ref_list_filter_order_id(session, client):
         [user, order1, order2, process, job1, order_job_ref1, order_job_ref2]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/order-job-refs?order_id={order1.id}")
+    response = client.get(f"{config.root_path}/order-job-refs?order_id={order1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -92,11 +92,11 @@ def test_read_order_job_ref_list_101(session, client):
         session.add_all([job, order_job_ref])
         session.commit()
     # In the first page we have 100 orders.
-    response = client.get(f"{ROOT_PATH}/order-job-refs")
+    response = client.get(f"{config.root_path}/order-job-refs")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/order-job-refs?skip=100")
+    response2 = client.get(f"{config.root_path}/order-job-refs?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -111,7 +111,7 @@ def test_read_order_job_ref_detail_one(session, client):
     order_job_ref = OrderJobRef(order=order, job=job)
     session.add_all([user, order, process, job, order_job_ref])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/order-job-refs/{order_job_ref.id}")
+    response = client.get(f"{config.root_path}/order-job-refs/{order_job_ref.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": order_job_ref.id,
@@ -121,5 +121,5 @@ def test_read_order_job_ref_detail_one(session, client):
 
 
 def test_read_order_job_ref_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/order-job-refs/-123")
+    response = client.get(f"{config.root_path}/order-job-refs/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_orders.py
+++ b/backend/tests/test_routes/test_orders.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Order, User
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_order_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/orders")
+    response = client.get(f"{config.root_path}/orders")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -15,7 +15,7 @@ def test_read_order_list_one(session, client):
     order = Order(user=user, order_constraints={})
     session.add_all([user, order])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/orders")
+    response = client.get(f"{config.root_path}/orders")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -38,7 +38,7 @@ def test_read_order_list_filter_user_id(session, client):
     order2 = Order(user=user2, order_constraints={})
     session.add_all([user1, user2, order1, order2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/orders?user_id={user1.id}")
+    response = client.get(f"{config.root_path}/orders?user_id={user1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -57,11 +57,11 @@ def test_read_order_list_101(session, client):
         session.add(order)
         session.commit()
     # In the first page we have 100 orders.
-    response = client.get(f"{ROOT_PATH}/orders")
+    response = client.get(f"{config.root_path}/orders")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/orders?skip=100")
+    response2 = client.get(f"{config.root_path}/orders?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -76,7 +76,7 @@ def test_read_order_detail_one(session, client):
     )
     session.add_all([user, order])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/orders/{order.id}")
+    response = client.get(f"{config.root_path}/orders/{order.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": order.id,
@@ -86,20 +86,21 @@ def test_read_order_detail_one(session, client):
 
 
 def test_read_order_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/orders/-123")
+    response = client.get(f"{config.root_path}/orders/-123")
     assert response.status_code == 404
 
 
 def test_create_order_no_auth(client):
     response = client.post(
-        f"{ROOT_PATH}/orders/", json={"order_constraints": {"gmpe": ["Abrahamson"]}}
+        f"{config.root_path}/orders/",
+        json={"order_constraints": {"gmpe": ["Abrahamson"]}},
     )
     assert response.status_code == 401
 
 
 def test_create_order_wrong_auth(client):
     response = client.post(
-        f"{ROOT_PATH}/orders/",
+        f"{config.root_path}/orders/",
         json={
             "order_constraints": {"gmpe": ["Abrahamson"]},
         },
@@ -113,7 +114,7 @@ def test_create_order_auth(client, session):
     session.add(user)
     session.commit()
     response = client.post(
-        f"{ROOT_PATH}/orders/",
+        f"{config.root_path}/orders/",
         json={
             "order_constraints": {"gmpe": ["Abrahamson"]},
         },

--- a/backend/tests/test_routes/test_processes.py
+++ b/backend/tests/test_routes/test_processes.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Process
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_process_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/processes")
+    response = client.get(f"{config.root_path}/processes")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -16,7 +16,7 @@ def test_read_process_list_one(session, client):
     )
     session.add(process)
     session.commit()
-    response = client.get(f"{ROOT_PATH}/processes")
+    response = client.get(f"{config.root_path}/processes")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -34,7 +34,7 @@ def test_read_process_list_filter_wps_identifier(session, client):
     process2 = Process(wps_url="https://rz-vm140.gfz-potsdam.de", wps_identifier="deus")
     session.add_all([process1, process2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/processes?wps_identifier=shakyground")
+    response = client.get(f"{config.root_path}/processes?wps_identifier=shakyground")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -53,7 +53,7 @@ def test_read_process_list_filter_wps_url(session, client):
     session.add_all([process1, process2])
     session.commit()
     response = client.get(
-        f"{ROOT_PATH}/processes",
+        f"{config.root_path}/processes",
         params={
             "wps_url": "https://rz-vm140.gfz-potsdam.de",
         },
@@ -76,11 +76,11 @@ def test_read_process_list_101(session, client):
         session.add(process)
         session.commit()
     # In the first page we have 100 processes.
-    response = client.get(f"{ROOT_PATH}/processes")
+    response = client.get(f"{config.root_path}/processes")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/processes?skip=100")
+    response2 = client.get(f"{config.root_path}/processes?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -91,7 +91,7 @@ def test_read_process_detail_one(session, client):
     )
     session.add(process)
     session.commit()
-    response = client.get(f"{ROOT_PATH}/processes/{process.id}")
+    response = client.get(f"{config.root_path}/processes/{process.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": process.id,
@@ -101,5 +101,5 @@ def test_read_process_detail_one(session, client):
 
 
 def test_read_process_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/processes/-123")
+    response = client.get(f"{config.root_path}/processes/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_product_types.py
+++ b/backend/tests/test_routes/test_product_types.py
@@ -1,11 +1,11 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import Job, Order, OrderJobRef, Process, User
 
 from ..base import cleanup_db, client, session
 
 
 def test_read_product_type_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/product-types")
+    response = client.get(f"{config.root_path}/product-types")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -17,7 +17,7 @@ def test_read_product_types_list_one(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/product-types")
+    response = client.get(f"{config.root_path}/product-types")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -35,7 +35,7 @@ def test_read_product_types_list_one_multiple_jobs(session, client):
     job2 = Job(process=process, status="Succeeded")
     session.add_all([process, job1, job2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/product-types")
+    response = client.get(f"{config.root_path}/product-types")
     assert response.status_code == 200
     # Still just one
     assert response.json() == [
@@ -54,7 +54,7 @@ def test_read_product_types_list_no_successful_jobs(session, client):
     job2 = Job(process=process, status="failed")
     session.add_all([process, job1, job2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/product-types")
+    response = client.get(f"{config.root_path}/product-types")
     assert response.status_code == 200
     # Still just one
     assert response.json() == []
@@ -73,11 +73,11 @@ def test_read_product_types_list_101(session, client):
         session.add(job)
         session.commit()
     # In the first page we have 100 jobs.
-    response = client.get(f"{ROOT_PATH}/product-types")
+    response = client.get(f"{config.root_path}/product-types")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/product-types?skip=100")
+    response2 = client.get(f"{config.root_path}/product-types?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -89,7 +89,7 @@ def test_read_product_type_detail_one(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/product-types/{process.id}")
+    response = client.get(f"{config.root_path}/product-types/{process.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": process.id,
@@ -104,10 +104,10 @@ def test_read_product_type_detail_no_succesful_job(session, client):
     job = Job(process=process, status="failed")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/product-types/{process.id}")
+    response = client.get(f"{config.root_path}/product-types/{process.id}")
     assert response.status_code == 404
 
 
 def test_read_product_type_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/product-types/-123")
+    response = client.get(f"{config.root_path}/product-types/-123")
     assert response.status_code == 404

--- a/backend/tests/test_routes/test_products.py
+++ b/backend/tests/test_routes/test_products.py
@@ -1,4 +1,4 @@
-from catalog_app.main import ROOT_PATH
+from catalog_app.main import config
 from catalog_app.models import (
     ComplexOutput,
     ComplexOutputAsInput,
@@ -13,7 +13,7 @@ from ..base import cleanup_db, client, session
 
 
 def test_read_product_list_empty(client):
-    response = client.get(f"{ROOT_PATH}/products")
+    response = client.get(f"{config.root_path}/products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -25,7 +25,7 @@ def test_read_product_list_one(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products")
+    response = client.get(f"{config.root_path}/products")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -43,7 +43,7 @@ def test_read_product_list_not_successful(session, client):
     job = Job(process=process, status="Failed")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products")
+    response = client.get(f"{config.root_path}/products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -57,7 +57,7 @@ def test_read_product_list_filter_product_type_id(session, client):
     job2 = Job(process=process2, status="Succeeded")
     session.add_all([process1, process2, job1, job2])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products?product_type_id={process1.id}")
+    response = client.get(f"{config.root_path}/products?product_type_id={process1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -83,7 +83,7 @@ def test_read_product_list_filter_order_id(session, client):
         [user, order1, order2, process1, job1, job2, order_job_ref1, order_job_ref2]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products?order_id={order1.id}")
+    response = client.get(f"{config.root_path}/products?order_id={order1.id}")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -107,11 +107,11 @@ def test_read_product_list_101(session, client):
         session.add(job)
         session.commit()
     # In the first page we have 100 jobs.
-    response = client.get(f"{ROOT_PATH}/products")
+    response = client.get(f"{config.root_path}/products")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/products?skip=100")
+    response2 = client.get(f"{config.root_path}/products?skip=100")
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -123,7 +123,7 @@ def test_read_product_detail_one(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job.id}")
+    response = client.get(f"{config.root_path}/products/{job.id}")
     assert response.status_code == 200
     assert response.json() == {
         "id": job.id,
@@ -139,12 +139,12 @@ def test_read_product_detail_not_successful(session, client):
     job = Job(process=process, status="failed")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job.id}")
+    response = client.get(f"{config.root_path}/products/{job.id}")
     assert response.status_code == 404
 
 
 def test_read_product_detail_none(client):
-    response = client.get(f"{ROOT_PATH}/products/-123")
+    response = client.get(f"{config.root_path}/products/-123")
     assert response.status_code == 404
 
 
@@ -155,7 +155,7 @@ def test_read_derived_product_list_empty(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job.id}/derived-products")
+    response = client.get(f"{config.root_path}/products/{job.id}/derived-products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -182,7 +182,7 @@ def test_read_derived_product_list_one(session, client):
         [process1, process2, job1, job2, complex_output, complex_output_as_input]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job1.id}/derived-products")
+    response = client.get(f"{config.root_path}/products/{job1.id}/derived-products")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -215,7 +215,7 @@ def test_read_derived_product_list_one_no_matter_how_many_inputs(session, client
         )
         session.add_all([complex_output, complex_output_as_input])
         session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job1.id}/derived-products")
+    response = client.get(f"{config.root_path}/products/{job1.id}/derived-products")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -248,7 +248,7 @@ def test_read_derived_product_list_none_as_failed(session, client):
         [process1, process2, job1, job2, complex_output, complex_output_as_input]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job1.id}/derived-products")
+    response = client.get(f"{config.root_path}/products/{job1.id}/derived-products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -277,11 +277,13 @@ def test_read_derived_product_list_101(session, client):
         )
         session.add_all([job1, jobN, complex_output_as_input])
         session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job1.id}/derived-products")
+    response = client.get(f"{config.root_path}/products/{job1.id}/derived-products")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/products/{job1.id}/derived-products?skip=100")
+    response2 = client.get(
+        f"{config.root_path}/products/{job1.id}/derived-products?skip=100"
+    )
     assert response2.status_code == 200
     assert len(response2.json()) == 1
 
@@ -293,7 +295,7 @@ def test_read_base_product_list_empty(session, client):
     job = Job(process=process, status="Succeeded")
     session.add_all([process, job])
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job.id}/base-products")
+    response = client.get(f"{config.root_path}/products/{job.id}/base-products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -320,7 +322,7 @@ def test_read_base_product_list_one(session, client):
         [process1, process2, job1, job2, complex_output, complex_output_as_input]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job2.id}/base-products")
+    response = client.get(f"{config.root_path}/products/{job2.id}/base-products")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -353,7 +355,7 @@ def test_read_base_product_list_one_no_matter_how_many_inputs(session, client):
         )
         session.add_all([complex_output, complex_output_as_input])
         session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job2.id}/base-products")
+    response = client.get(f"{config.root_path}/products/{job2.id}/base-products")
     assert response.status_code == 200
     assert response.json() == [
         {
@@ -386,7 +388,7 @@ def test_read_base_product_list_none_as_not_successful(session, client):
         [process1, process2, job1, job2, complex_output, complex_output_as_input]
     )
     session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job2.id}/base-products")
+    response = client.get(f"{config.root_path}/products/{job2.id}/base-products")
     assert response.status_code == 200
     assert response.json() == []
 
@@ -415,10 +417,12 @@ def test_read_base_product_list_101(session, client):
         )
         session.add_all([jobN, complex_output, complex_output_as_input])
         session.commit()
-    response = client.get(f"{ROOT_PATH}/products/{job1.id}/base-products")
+    response = client.get(f"{config.root_path}/products/{job1.id}/base-products")
     assert response.status_code == 200
     assert len(response.json()) == 100
     # On the second one we have only one left.
-    response2 = client.get(f"{ROOT_PATH}/products/{job1.id}/base-products?skip=100")
+    response2 = client.get(
+        f"{config.root_path}/products/{job1.id}/base-products?skip=100"
+    )
     assert response2.status_code == 200
     assert len(response2.json()) == 1

--- a/docker-compose-with-wrappers.yml
+++ b/docker-compose-with-wrappers.yml
@@ -223,6 +223,8 @@ services:
     environment:
       ROOT_PATH: '/api/v1'
       SQLALCHEMY_DATABASE_URL: 'postgresql://postgres:postgres@db:5432/postgres'
+      BACKEND_USER_EMAIL: dummy@localhost
+      BACKEND_USER_PASSWORD: test123
 
   backend_migrations:
     image: flyway/flyway


### PR DESCRIPTION
I changed the user creation in the backend.

Now it is only possible to set the user with the env variables `BACKEND_USER_EMAIL` and `BACKEND_USER_PASSWORD`. The registration api is now deactivated.

Rest of the changes is a bit refactoring (password handling, configuration handling).