### PR TITLE
Integrate modelprop tsunami wrapper into docker compose files

### DIFF
--- a/docker-compose-uncert.yml
+++ b/docker-compose-uncert.yml
@@ -25,7 +25,7 @@ services:
       spring.datasource.username: '${DATABASE_USER:?error}'
       spring.datasource.password: '${DATABASE_PASSWORD:?error}'
       pulsar.pulsarURL: 'pulsar://queue:6650'
-      pulsar.inputTopics: 'shakemap-resampler-success,assetmaster-success,modelprop-success'
+      pulsar.inputTopics: 'shakemap-resampler-success,assetmaster-success,modelprop-eq-success'
       pulsar.orderTopic: 'new-order'
       pulsar.outputTopic: 'deus-success'
       pulsar.failureTopic: 'deus-failure'
@@ -71,7 +71,7 @@ services:
       filestorage.bucketName: riesgosfiles
       filestorage.access: ${FILESTORAGE_SERVER:?error}/riesgosfiles/
 
-  modelprop_wrapper:
+  modelprop_eq_wrapper:
     image: spring-boot-image
     build:
       context: asyncwrapper/dockerfile-spring-boot-baseimage
@@ -85,7 +85,7 @@ services:
       - queue
       - filestorage
     environment:
-      appID: 'modelprop-asyncwrapper'
+      appID: 'modelprop-eq-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ModelpropEqWrapper'
       spring.datasource.url: 'jdbc:postgresql://db:5432/${DATABASE_USER:?error}'
       spring.datasource.username: '${DATABASE_USER:?error}'
@@ -93,8 +93,42 @@ services:
       pulsar.pulsarURL: 'pulsar://queue:6650'
       pulsar.inputTopics: ''
       pulsar.orderTopic: 'new-order'
-      pulsar.outputTopic: 'modelprop-success'
-      pulsar.failureTopic: 'modelprop-failure'
+      pulsar.outputTopic: 'modelprop-eq-success'
+      pulsar.failureTopic: 'modelprop-eq-failure'
+      wps.wpsUrl: 'https://rz-vm140.gfz-potsdam.de/wps/WebProcessingService'
+      wps.wpsVersion: '2.0.0'
+      wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ModelpropProcess'
+      filestorage.endpoint: http://filestorage:9000
+      filestorage.user: ${FILESTORAGE_USER:?error}
+      filestorage.password: ${FILESTORAGE_PASSWORD:?error}
+      filestorage.bucketName: riesgosfiles
+      filestorage.access: ${FILESTORAGE_SERVER:?error}/riesgosfiles/
+
+  modelprop_ts_wrapper:
+    image: spring-boot-image
+    build:
+      context: asyncwrapper/dockerfile-spring-boot-baseimage
+    volumes:
+      - './asyncwrapper/target/asyncwrapper-0.0.1-SNAPSHOT.jar:/app.jar'
+    depends_on:
+      - db
+      - queue
+    networks:
+      - db
+      - queue
+      - filestorage
+    environment:
+      appID: 'modelprop-ts-asyncwrapper'
+      wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ModelpropTsWrapper'
+      spring.datasource.url: 'jdbc:postgresql://db:5432/${DATABASE_USER:?error}'
+      spring.datasource.username: '${DATABASE_USER:?error}'
+      spring.datasource.password: '${DATABASE_PASSWORD:?error}'
+      pulsar.pulsarURL: 'pulsar://queue:6650'
+      # TODO Listen to tsunami once we got the wrapper
+      pulsar.inputTopics: ''
+      pulsar.orderTopic: 'new-order'
+      pulsar.outputTopic: 'modelprop-ts-success'
+      pulsar.failureTopic: 'modelprop-ts-failure'
       wps.wpsUrl: 'https://rz-vm140.gfz-potsdam.de/wps/WebProcessingService'
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ModelpropProcess'

--- a/docker-compose-with-wrappers.yml
+++ b/docker-compose-with-wrappers.yml
@@ -26,7 +26,7 @@ services:
       spring.datasource.username: 'postgres'
       spring.datasource.password: 'postgres'
       pulsar.pulsarURL: 'pulsar://queue:6650'
-      pulsar.inputTopics: 'shakemap-resampler-success,assetmaster-success,modelprop-success'
+      pulsar.inputTopics: 'shakemap-resampler-success,assetmaster-success,modelprop-eq-success'
       pulsar.orderTopic: 'new-order'
       pulsar.outputTopic: 'deus-success'
       pulsar.failureTopic: 'deus-failure'
@@ -73,7 +73,7 @@ services:
       filestorage.bucketName: riesgosfiles
       filestorage.access: http://filestorage:9000/riesgosfiles/
 
-  modelprop_wrapper:
+  modelprop_eq_wrapper:
     image: spring-boot-image
     build:
       context: asyncwrapper/dockerfile-spring-boot-baseimage
@@ -88,7 +88,7 @@ services:
       - filestorage
       - wps
     environment:
-      appID: 'modelprop-asyncwrapper'
+      appID: 'modelprop-eq-asyncwrapper'
       wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ModelpropEqWrapper'
       spring.datasource.url: 'jdbc:postgresql://db:5432/postgres'
       spring.datasource.username: 'postgres'
@@ -96,8 +96,42 @@ services:
       pulsar.pulsarURL: 'pulsar://queue:6650'
       pulsar.inputTopics: ''
       pulsar.orderTopic: 'new-order'
-      pulsar.outputTopic: 'modelprop-success'
-      pulsar.failureTopic: 'modelprop-failure'
+      pulsar.outputTopic: 'modelprop-eq-success'
+      pulsar.failureTopic: 'modelprop-eq-failure'
+      wps.wpsUrl: 'http://riesgos-wps:8080/wps/WebProcessingService'
+      wps.wpsVersion: '2.0.0'
+      wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ModelpropProcess'
+      filestorage.endpoint: http://filestorage:9000
+      filestorage.user: admin
+      filestorage.password: secretpassword
+      filestorage.bucketName: riesgosfiles
+      filestorage.access: http://filestorage:9000/riesgosfiles/
+
+  modelprop_ts_wrapper:
+    image: spring-boot-image
+    build:
+      context: asyncwrapper/dockerfile-spring-boot-baseimage
+    volumes:
+      - './asyncwrapper/target/asyncwrapper-0.0.1-SNAPSHOT.jar:/app.jar'
+    depends_on:
+      - db
+      - queue
+    networks:
+      - db
+      - queue
+      - filestorage
+      - wps
+    environment:
+      appID: 'modelprop-ts-asyncwrapper'
+      wrapperClass: 'org.n.riesgos.asyncwrapper.dummy.ModelpropTsWrapper'
+      spring.datasource.url: 'jdbc:postgresql://db:5432/postgres'
+      spring.datasource.username: 'postgres'
+      spring.datasource.password: 'postgres'
+      pulsar.pulsarURL: 'pulsar://queue:6650'
+      pulsar.inputTopics: ''
+      pulsar.orderTopic: 'new-order'
+      pulsar.outputTopic: 'modelprop-ts-success'
+      pulsar.failureTopic: 'modelprop-ts-failure'
       wps.wpsUrl: 'http://riesgos-wps:8080/wps/WebProcessingService'
       wps.wpsVersion: '2.0.0'
       wps.process: 'org.n52.gfz.riesgos.algorithm.impl.ModelpropProcess'

--- a/docker-compose-with-wrappers.yml
+++ b/docker-compose-with-wrappers.yml
@@ -128,6 +128,7 @@ services:
       spring.datasource.username: 'postgres'
       spring.datasource.password: 'postgres'
       pulsar.pulsarURL: 'pulsar://queue:6650'
+      # TODO Listen to tsunami once we got the wrapper
       pulsar.inputTopics: ''
       pulsar.orderTopic: 'new-order'
       pulsar.outputTopic: 'modelprop-ts-success'


### PR DESCRIPTION
This is the change to include the modelprop for the tsunami case.

We had already had a lot of stuff prepared, so that it looks like it could work:

- There was already a seperate ModelpropTsWrapper that has default constraints to use Medina & Suppasri Schemas.
- The constraint management already seperates the Modelprop for earthquakes & tsunamis as it works on the wrapper name (`eq-modelprop` vs `ts-modelprop`).
- The deus wrapper already filters for modelprop results that are done with the earthquake schemas (currently only sara).

So as far as I can see the only thing that was needed was to adjust the docker-compose files:
- rename the modelprop container name (so that we know it is the earthquake specific one)
- add the wrapper for the tsunami modelprop.
- rename the input & output topics for those wrappers.

Things still todo:
- [ ] test with the frontend
- [ ] eventually adjust the input topcis for the tsunami modelprop so that we only call it after we run the tsunami run 