### PR TITLE
Add more meta information & error handling

### DIFF
--- a/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/datamanagement/DatamanagementRepo.kt
+++ b/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/datamanagement/DatamanagementRepo.kt
@@ -409,6 +409,19 @@ class DatamanagementRepo (
     }
 
     /**
+     * Set the exception report field for the job.
+     */
+    fun setJobExceptionReport (jobId: Long, exceptionReport: String) {
+        val sql = """
+            update jobs
+            set exception_report = ?
+            where id = ?
+        """.trimIndent()
+
+        jdbcTemplate.update(sql, exceptionReport, jobId)
+    }
+
+    /**
      * Insert a complex output data in the database.
      */
     fun insertComplexOutput (jobId: Long, wpsIdentifier: String, link: String, mimeType: String, xmlschema: String, encoding: String): ComplexOutput {

--- a/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/dummy/AbstractWrapper.kt
+++ b/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/dummy/AbstractWrapper.kt
@@ -20,6 +20,8 @@ import org.n.riesgos.asyncwrapper.pulsar.PulsarPublisher
 import org.n.riesgos.asyncwrapper.utils.retry
 import org.n52.geoprocessing.wps.client.WPSClientException
 import java.io.IOException
+import java.io.PrintWriter
+import java.io.StringWriter
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
@@ -312,7 +314,14 @@ abstract class AbstractWrapper(val publisher : PulsarPublisher, val wpsConfigura
             LOGGER.info("WPS call failed")
             LOGGER.info("WPS call failed because of: ${e.message}")
             e.printStackTrace()
+
             datamanagementRepo().updateJobStatus(jobId, WPS_JOB_STATUS_FAILED)
+
+            val sw = StringWriter()
+            val pw = PrintWriter(sw)
+            e.printStackTrace(pw)
+            val exceptionReport = sw.toString()
+            datamanagementRepo().setJobExceptionReport(jobId, exceptionReport)
             // => without the re-raise we would be able to run the loop & don't
             // have to stop when one call has an exception from the WPS itself.
         }

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add python3-dev gcc libc-dev g++
 RUN /usr/local/bin/python -m pip install --upgrade pip
 
 
-RUN pip install fastapi uvicorn psycopg2-binary sqlalchemy pytest requests httpx
+RUN pip install fastapi uvicorn psycopg2-binary sqlalchemy pytest requests httpx pytz
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 

--- a/backend/catalog_app/database.py
+++ b/backend/catalog_app/database.py
@@ -1,7 +1,6 @@
 from .config import Config
 from sqlalchemy import create_engine
-from sqlalchemy.ext.declarative import declarative_base
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, declarative_base
 
 config = Config()
 engine = create_engine(config.sqlalchemy_database_url)

--- a/backend/catalog_app/models.py
+++ b/backend/catalog_app/models.py
@@ -1,11 +1,23 @@
-import binascii
-import os
-import hashlib
 import base64
-from sqlalchemy import JSON, Boolean, Column, Float, ForeignKey, Integer, String, Text
+import binascii
+import hashlib
+import os
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    Column,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+)
 from sqlalchemy.orm import relationship
 
 from .database import Base
+from .utils import utc_now
 
 
 class Process(Base):
@@ -13,6 +25,7 @@ class Process(Base):
     id = Column(Integer, primary_key=True)
     wps_url = Column(String(256))
     wps_identifier = Column(String(256))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     jobs = relationship("Job", back_populates="process")
 
 
@@ -23,6 +36,7 @@ class User(Base):
     password_hash = Column(String(256))
     apikey = Column(String(256))
     superuser = Column(Boolean, default=False)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     orders = relationship("Order", back_populates="user")
 
     @staticmethod
@@ -59,6 +73,7 @@ class Order(Base):
     user_id = Column(Integer, ForeignKey("users.id"))
     user = relationship("User", back_populates="orders")
     order_constraints = Column(JSON)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     order_job_refs = relationship("OrderJobRef", back_populates="order")
 
 
@@ -68,6 +83,7 @@ class Job(Base):
     process_id = Column(Integer, ForeignKey("processes.id"))
     process = relationship("Process", back_populates="jobs")
     status = Column(String(16))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
     order_job_refs = relationship("OrderJobRef", back_populates="job")
     complex_outputs = relationship("ComplexOutput", back_populates="job")
@@ -87,6 +103,7 @@ class OrderJobRef(Base):
     order = relationship("Order", back_populates="order_job_refs")
     job_id = Column(Integer, ForeignKey("jobs.id"))
     job = relationship("Job", back_populates="order_job_refs")
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
 
 class ComplexOutput(Base):
@@ -99,6 +116,7 @@ class ComplexOutput(Base):
     mime_type = Column(String(64))
     xmlschema = Column(String(256))
     encoding = Column(String(16))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
     inputs = relationship("ComplexOutputAsInput", back_populates="complex_output")
 
 
@@ -110,6 +128,7 @@ class ComplexOutputAsInput(Base):
     wps_identifier = Column(String(256))
     complex_output_id = Column(Integer, ForeignKey("complex_outputs.id"))
     complex_output = relationship("ComplexOutput", back_populates="inputs")
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
 
 class ComplexInput(Base):
@@ -122,6 +141,7 @@ class ComplexInput(Base):
     mime_type = Column(String(64))
     xmlschema = Column(String(256))
     encoding = Column(String(16))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
 
 class ComplexInputAsValue(Base):
@@ -134,6 +154,7 @@ class ComplexInputAsValue(Base):
     mime_type = Column(String(64))
     xmlschema = Column(String(256))
     encoding = Column(String(16))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
 
 class LiteralInput(Base):
@@ -143,6 +164,7 @@ class LiteralInput(Base):
     job = relationship("Job", back_populates="literal_inputs")
     wps_identifier = Column(String(256))
     input_value = Column(Text)
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
 
 
 class BboxInput(Base):
@@ -156,3 +178,4 @@ class BboxInput(Base):
     upper_corner_x = Column(Float)
     upper_corner_y = Column(Float)
     crs = Column(String(32))
+    created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)

--- a/backend/catalog_app/models.py
+++ b/backend/catalog_app/models.py
@@ -84,6 +84,7 @@ class Job(Base):
     process = relationship("Process", back_populates="jobs")
     status = Column(String(16))
     created_at = Column(DateTime(timezone=True), default=utc_now, nullable=False)
+    exception_report = Column(Text, nullable=True)
 
     order_job_refs = relationship("OrderJobRef", back_populates="job")
     complex_outputs = relationship("ComplexOutput", back_populates="job")

--- a/backend/catalog_app/schemas.py
+++ b/backend/catalog_app/schemas.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Optional
 
 from pydantic import BaseModel
@@ -15,6 +16,7 @@ class BboxInputBase(BaseModel):
 
 class BboxInput(BboxInputBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -31,6 +33,7 @@ class ComplexInputBase(BaseModel):
 
 class ComplexInput(ComplexInputBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -47,6 +50,7 @@ class ComplexInputAsValueBase(BaseModel):
 
 class ComplexInputAsValue(ComplexInputAsValueBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -63,6 +67,7 @@ class ComplexOutputBase(BaseModel):
 
 class ComplexOutput(ComplexOutputBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -76,6 +81,7 @@ class ComplexOutputAsInputBase(BaseModel):
 
 class ComplexOutputAsInput(ComplexOutputAsInputBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -88,6 +94,7 @@ class JobBase(BaseModel):
 
 class Job(JobBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -101,6 +108,7 @@ class LiteralInputBase(BaseModel):
 
 class LiteralInput(LiteralInputBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -113,6 +121,7 @@ class OrderBase(BaseModel):
 
 class Order(OrderBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -129,6 +138,7 @@ class OrderJobRefBase(BaseModel):
 
 class OrderJobRef(OrderJobRefBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True
@@ -141,6 +151,7 @@ class ProcessBase(BaseModel):
 
 class Process(ProcessBase):
     id: int
+    created_at: datetime.datetime
 
     class Config:
         orm_mode = True

--- a/backend/catalog_app/schemas.py
+++ b/backend/catalog_app/schemas.py
@@ -90,6 +90,7 @@ class ComplexOutputAsInput(ComplexOutputAsInputBase):
 class JobBase(BaseModel):
     process_id: int
     status: str
+    exception_report: Optional[str]
 
 
 class Job(JobBase):

--- a/backend/catalog_app/utils.py
+++ b/backend/catalog_app/utils.py
@@ -1,0 +1,7 @@
+import datetime
+
+import pytz
+
+
+def utc_now():
+    return pytz.utc.localize(datetime.datetime.now())

--- a/backend/migrations/V4__Add_created_at.sql
+++ b/backend/migrations/V4__Add_created_at.sql
@@ -1,0 +1,12 @@
+alter table processes add column created_at timestamp with time zone not null default now();
+alter table users add column created_at timestamp with time zone not null default now();
+alter table orders add column created_at timestamp with time zone not null default now();
+alter table jobs add column created_at timestamp with time zone not null default now();
+alter table order_job_refs add column created_at timestamp with time zone not null default now();
+alter table complex_outputs add column created_at timestamp with time zone not null default now();
+alter table complex_outputs_as_inputs add column created_at timestamp with time zone not null default now();
+alter table complex_inputs add column created_at timestamp with time zone not null default now();
+alter table complex_inputs_as_values add column created_at timestamp with time zone not null default now();
+alter table literal_inputs add column created_at timestamp with time zone not null default now();
+alter table bbox_inputs add column created_at timestamp with time zone not null default now();
+alter table stored_links add column created_at timestamp with time zone not null default now();

--- a/backend/migrations/V5__Add_exception_column.sql
+++ b/backend/migrations/V5__Add_exception_column.sql
@@ -1,0 +1,1 @@
+alter table jobs add column exception_report text;

--- a/backend/tests/test_routes/test_bbox_inputs.py
+++ b/backend/tests/test_routes/test_bbox_inputs.py
@@ -28,18 +28,20 @@ def test_read_bbox_input_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/bbox-inputs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": bbox_input.id,
-            "job_id": job.id,
-            "wps_identifier": "bbox",
-            "lower_corner_x": 1.1,
-            "lower_corner_y": 52,
-            "upper_corner_x": 2.2,
-            "upper_corner_y": 53,
-            "crs": "epsg:4326",
-        }
-    ]
+    expected = {
+        "id": bbox_input.id,
+        "job_id": job.id,
+        "wps_identifier": "bbox",
+        "lower_corner_x": 1.1,
+        "lower_corner_y": 52,
+        "upper_corner_x": 2.2,
+        "upper_corner_y": 53,
+        "crs": "epsg:4326",
+    }
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_bbox_input_list_filter_wps_identifier(session, client):
@@ -69,18 +71,20 @@ def test_read_bbox_input_list_filter_wps_identifier(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/bbox-inputs?wps_identifier=bbox2")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": bbox_input2.id,
-            "job_id": job.id,
-            "wps_identifier": "bbox2",
-            "lower_corner_x": 1.1,
-            "lower_corner_y": 52,
-            "upper_corner_x": 2.2,
-            "upper_corner_y": 53,
-            "crs": "epsg:4326",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": bbox_input2.id,
+        "job_id": job.id,
+        "wps_identifier": "bbox2",
+        "lower_corner_x": 1.1,
+        "lower_corner_y": 52,
+        "upper_corner_x": 2.2,
+        "upper_corner_y": 53,
+        "crs": "epsg:4326",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_bbox_input_list_filter_process_id(session, client):
@@ -112,18 +116,20 @@ def test_read_bbox_input_list_filter_process_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/bbox-inputs?process_id={process2.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": bbox_input2.id,
-            "job_id": job2.id,
-            "wps_identifier": "bbox2",
-            "lower_corner_x": 1.1,
-            "lower_corner_y": 52,
-            "upper_corner_x": 2.2,
-            "upper_corner_y": 53,
-            "crs": "epsg:4326",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": bbox_input2.id,
+        "job_id": job2.id,
+        "wps_identifier": "bbox2",
+        "lower_corner_x": 1.1,
+        "lower_corner_y": 52,
+        "upper_corner_x": 2.2,
+        "upper_corner_y": 53,
+        "crs": "epsg:4326",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_bbox_input_list_filter_job_id(session, client):
@@ -154,18 +160,20 @@ def test_read_bbox_input_list_filter_job_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/bbox-inputs?job_id={job2.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": bbox_input2.id,
-            "job_id": job2.id,
-            "wps_identifier": "bbox2",
-            "lower_corner_x": 1.1,
-            "lower_corner_y": 52,
-            "upper_corner_x": 2.2,
-            "upper_corner_y": 53,
-            "crs": "epsg:4326",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": bbox_input2.id,
+        "job_id": job2.id,
+        "wps_identifier": "bbox2",
+        "lower_corner_x": 1.1,
+        "lower_corner_y": 52,
+        "upper_corner_x": 2.2,
+        "upper_corner_y": 53,
+        "crs": "epsg:4326",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_bbox_input_list_101(session, client):
@@ -217,7 +225,7 @@ def test_read_bbox_input_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/bbox-inputs/{bbox_input.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": bbox_input.id,
         "job_id": job.id,
         "wps_identifier": "bbox",
@@ -227,6 +235,9 @@ def test_read_bbox_input_detail_one(session, client):
         "upper_corner_y": 53,
         "crs": "epsg:4326",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_bbox_input_detail_none(client):

--- a/backend/tests/test_routes/test_complex_inputs.py
+++ b/backend/tests/test_routes/test_complex_inputs.py
@@ -27,17 +27,19 @@ def test_read_complex_input_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_wps_identifier(session, client):
@@ -65,17 +67,19 @@ def test_read_complex_input_list_filter_wps_identifier(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs?wps_identifier=shakemap1")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_job_id(session, client):
@@ -104,17 +108,19 @@ def test_read_complex_input_list_filter_job_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs?job_id={job2.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job2.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job2.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_process_id(session, client):
@@ -147,17 +153,19 @@ def test_read_complex_input_list_filter_process_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs?process_id={process2.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job2.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job2.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_101(session, client):
@@ -207,7 +215,7 @@ def test_read_complex_input_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs/{complex_input.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": complex_input.id,
         "job_id": job.id,
         "wps_identifier": "shakemap",
@@ -216,6 +224,9 @@ def test_read_complex_input_detail_one(session, client):
         "xmlschema": "https://shakemap",
         "encoding": "UTF-8",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_complex_input_detail_none(client):

--- a/backend/tests/test_routes/test_complex_inputs_as_values.py
+++ b/backend/tests/test_routes/test_complex_inputs_as_values.py
@@ -27,17 +27,19 @@ def test_read_complex_input_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-inputs-as-values")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap",
-            "input_value": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap",
+        "input_value": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_wps_identifier(session, client):
@@ -67,17 +69,19 @@ def test_read_complex_input_list_filter_wps_identifier(session, client):
         f"{config.root_path}/complex-inputs-as-values?wps_identifier=shakemap1"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap1",
-            "input_value": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap1",
+        "input_value": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_job_id(session, client):
@@ -108,17 +112,19 @@ def test_read_complex_input_list_filter_job_id(session, client):
         f"{config.root_path}/complex-inputs-as-values?job_id={job2.id}"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job2.id,
-            "wps_identifier": "shakemap1",
-            "input_value": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job2.id,
+        "wps_identifier": "shakemap1",
+        "input_value": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_filter_process_id(session, client):
@@ -150,17 +156,19 @@ def test_read_complex_input_list_filter_process_id(session, client):
         f"{config.root_path}/complex-inputs-as-values?process_id={process2.id}"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_input1.id,
-            "job_id": job2.id,
-            "wps_identifier": "shakemap1",
-            "input_value": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    assert len(response.json()) == 1
+    expected = {
+        "id": complex_input1.id,
+        "job_id": job2.id,
+        "wps_identifier": "shakemap1",
+        "input_value": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_input_list_101(session, client):
@@ -212,7 +220,7 @@ def test_read_complex_input_detail_one(session, client):
         f"{config.root_path}/complex-inputs-as-values/{complex_input.id}"
     )
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": complex_input.id,
         "job_id": job.id,
         "wps_identifier": "shakemap",
@@ -221,6 +229,9 @@ def test_read_complex_input_detail_one(session, client):
         "xmlschema": "https://shakemap",
         "encoding": "UTF-8",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_complex_input_detail_none(client):

--- a/backend/tests/test_routes/test_complex_outputs.py
+++ b/backend/tests/test_routes/test_complex_outputs.py
@@ -27,17 +27,20 @@ def test_read_complex_output_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-outputs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    expected = {
+        "id": complex_output.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_list_filter_wps_identifier(session, client):
@@ -67,17 +70,20 @@ def test_read_complex_output_list_filter_wps_identifier(session, client):
         f"{config.root_path}/complex-outputs?wps_identifier=shakemap1"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output1.id,
-            "job_id": job.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    expected = {
+        "id": complex_output1.id,
+        "job_id": job.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_list_filter_job_id(session, client):
@@ -106,17 +112,20 @@ def test_read_complex_output_list_filter_job_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-outputs?job_id={job1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output1.id,
-            "job_id": job1.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    expected = {
+        "id": complex_output1.id,
+        "job_id": job1.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_list_filter_process_id(session, client):
@@ -148,17 +157,20 @@ def test_read_complex_output_list_filter_process_id(session, client):
         f"{config.root_path}/complex-outputs?process_id={process1.id}"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output1.id,
-            "job_id": job1.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "application/xml",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    expected = {
+        "id": complex_output1.id,
+        "job_id": job1.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "application/xml",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_list_filter_mime_type(session, client):
@@ -188,17 +200,20 @@ def test_read_complex_output_list_filter_mime_type(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-outputs?mime_type=abc")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output1.id,
-            "job_id": job1.id,
-            "wps_identifier": "shakemap1",
-            "link": "https://download",
-            "mime_type": "abc",
-            "xmlschema": "https://shakemap",
-            "encoding": "UTF-8",
-        }
-    ]
+    expected = {
+        "id": complex_output1.id,
+        "job_id": job1.id,
+        "wps_identifier": "shakemap1",
+        "link": "https://download",
+        "mime_type": "abc",
+        "xmlschema": "https://shakemap",
+        "encoding": "UTF-8",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_list_101(session, client):
@@ -248,7 +263,7 @@ def test_read_complex_output_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-outputs/{complex_output.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": complex_output.id,
         "job_id": job.id,
         "wps_identifier": "shakemap",
@@ -257,6 +272,9 @@ def test_read_complex_output_detail_one(session, client):
         "xmlschema": "https://shakemap",
         "encoding": "UTF-8",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_complex_output_detail_none(client):

--- a/backend/tests/test_routes/test_complex_outputs_as_inputs.py
+++ b/backend/tests/test_routes/test_complex_outputs_as_inputs.py
@@ -30,14 +30,16 @@ def test_read_complex_output_as_input_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/complex-outputs-as-inputs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output_as_input.id,
-            "job_id": job.id,
-            "wps_identifier": "intensity",
-            "complex_output_id": complex_output.id,
-        }
-    ]
+    expected = {
+        "id": complex_output_as_input.id,
+        "job_id": job.id,
+        "wps_identifier": "intensity",
+        "complex_output_id": complex_output.id,
+    }
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_as_input_list_filter_wps_identifier(session, client):
@@ -73,14 +75,16 @@ def test_read_complex_output_as_input_list_filter_wps_identifier(session, client
         f"{config.root_path}/complex-outputs-as-inputs?wps_identifier=intensity1"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output_as_input1.id,
-            "job_id": job.id,
-            "wps_identifier": "intensity1",
-            "complex_output_id": complex_output.id,
-        }
-    ]
+    expected = {
+        "id": complex_output_as_input1.id,
+        "job_id": job.id,
+        "wps_identifier": "intensity1",
+        "complex_output_id": complex_output.id,
+    }
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_as_input_list_filter_job_id(session, client):
@@ -118,14 +122,16 @@ def test_read_complex_output_as_input_list_filter_job_id(session, client):
         f"{config.root_path}/complex-outputs-as-inputs?job_id={job1.id}"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output_as_input1.id,
-            "job_id": job1.id,
-            "wps_identifier": "intensity1",
-            "complex_output_id": complex_output.id,
-        }
-    ]
+    expected = {
+        "id": complex_output_as_input1.id,
+        "job_id": job1.id,
+        "wps_identifier": "intensity1",
+        "complex_output_id": complex_output.id,
+    }
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_as_input_list_filter_process_id(session, client):
@@ -165,14 +171,16 @@ def test_read_complex_output_as_input_list_filter_process_id(session, client):
         f"{config.root_path}/complex-outputs-as-inputs?process_id={process1.id}"
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": complex_output_as_input1.id,
-            "job_id": job1.id,
-            "wps_identifier": "intensity1",
-            "complex_output_id": complex_output.id,
-        }
-    ]
+    expected = {
+        "id": complex_output_as_input1.id,
+        "job_id": job1.id,
+        "wps_identifier": "intensity1",
+        "complex_output_id": complex_output.id,
+    }
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_complex_output_as_input_list_101(session, client):
@@ -230,12 +238,16 @@ def test_read_complex_output_as_input_detail_one(session, client):
         f"{config.root_path}/complex-outputs-as-inputs/{complex_output_as_input.id}"
     )
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": complex_output_as_input.id,
         "job_id": job.id,
         "wps_identifier": "intensity",
         "complex_output_id": complex_output.id,
     }
+
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_complex_output_as_input_detail_none(client):

--- a/backend/tests/test_routes/test_jobs.py
+++ b/backend/tests/test_routes/test_jobs.py
@@ -23,6 +23,7 @@ def test_read_job_list_one(session, client):
         "id": job.id,
         "process_id": process.id,
         "status": "pending",
+        "exception_report": None,
     }
 
     assert len(response.json()) == 1
@@ -46,6 +47,7 @@ def test_read_job_list_filter_process_id(session, client):
         "id": job1.id,
         "process_id": process1.id,
         "status": "pending",
+        "exception_report": None,
     }
 
     assert len(response.json()) == 1
@@ -58,7 +60,7 @@ def test_read_job_list_filter_status(session, client):
     process1 = Process(
         wps_url="https://rz-vm140.gfz-potsdam.de", wps_identifier="shakyground"
     )
-    job1 = Job(process=process1, status="running")
+    job1 = Job(process=process1, status="running", exception_report="Stacktrace...")
     job2 = Job(process=process1, status="pending")
     session.add_all([process1, job1, job2])
     session.commit()
@@ -68,6 +70,7 @@ def test_read_job_list_filter_status(session, client):
         "id": job1.id,
         "process_id": process1.id,
         "status": "running",
+        "exception_report": "Stacktrace...",
     }
 
     assert len(response.json()) == 1
@@ -97,6 +100,7 @@ def test_read_job_list_filter_order_id(session, client):
         "id": job1.id,
         "process_id": process1.id,
         "status": "running",
+        "exception_report": None,
     }
 
     assert len(response.json()) == 1
@@ -140,6 +144,7 @@ def test_read_job_detail_one(session, client):
         "id": job.id,
         "process_id": process.id,
         "status": "pending",
+        "exception_report": None,
     }
     for key, value in expected.items():
         assert response.json()[key] == value

--- a/backend/tests/test_routes/test_jobs.py
+++ b/backend/tests/test_routes/test_jobs.py
@@ -19,13 +19,16 @@ def test_read_job_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/jobs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": job.id,
-            "process_id": process.id,
-            "status": "pending",
-        }
-    ]
+    expected = {
+        "id": job.id,
+        "process_id": process.id,
+        "status": "pending",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_job_list_filter_process_id(session, client):
@@ -39,13 +42,16 @@ def test_read_job_list_filter_process_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/jobs?process_id={process1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": job1.id,
-            "process_id": process1.id,
-            "status": "pending",
-        }
-    ]
+    expected = {
+        "id": job1.id,
+        "process_id": process1.id,
+        "status": "pending",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_job_list_filter_status(session, client):
@@ -58,13 +64,16 @@ def test_read_job_list_filter_status(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/jobs?status=running")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": job1.id,
-            "process_id": process1.id,
-            "status": "running",
-        }
-    ]
+    expected = {
+        "id": job1.id,
+        "process_id": process1.id,
+        "status": "running",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_job_list_filter_order_id(session, client):
@@ -84,13 +93,16 @@ def test_read_job_list_filter_order_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/jobs?order_id={order1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": job1.id,
-            "process_id": process1.id,
-            "status": "running",
-        }
-    ]
+    expected = {
+        "id": job1.id,
+        "process_id": process1.id,
+        "status": "running",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_job_list_101(session, client):
@@ -124,11 +136,14 @@ def test_read_job_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/jobs/{job.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": job.id,
         "process_id": process.id,
         "status": "pending",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_job_detail_none(client):

--- a/backend/tests/test_routes/test_literal_inputs.py
+++ b/backend/tests/test_routes/test_literal_inputs.py
@@ -22,14 +22,17 @@ def test_read_literal_input_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/literal-inputs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": literal_input.id,
-            "job_id": job.id,
-            "wps_identifier": "gmpe",
-            "input_value": "Abrahamson",
-        }
-    ]
+    expected = {
+        "id": literal_input.id,
+        "job_id": job.id,
+        "wps_identifier": "gmpe",
+        "input_value": "Abrahamson",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_literal_input_list_filter_wps_identifier(session, client):
@@ -45,14 +48,17 @@ def test_read_literal_input_list_filter_wps_identifier(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/literal-inputs?wps_identifier=gmpe")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": literal_input1.id,
-            "job_id": job.id,
-            "wps_identifier": "gmpe",
-            "input_value": "Abrahamson",
-        }
-    ]
+    expected = {
+        "id": literal_input1.id,
+        "job_id": job.id,
+        "wps_identifier": "gmpe",
+        "input_value": "Abrahamson",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_literal_input_list_filter_job_id(session, client):
@@ -69,14 +75,17 @@ def test_read_literal_input_list_filter_job_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/literal-inputs?job_id={job1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": literal_input1.id,
-            "job_id": job1.id,
-            "wps_identifier": "gmpe",
-            "input_value": "Abrahamson",
-        }
-    ]
+    expected = {
+        "id": literal_input1.id,
+        "job_id": job1.id,
+        "wps_identifier": "gmpe",
+        "input_value": "Abrahamson",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_literal_input_list_filter_process_id(session, client):
@@ -94,14 +103,17 @@ def test_read_literal_input_list_filter_process_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/literal-inputs?process_id={process1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": literal_input1.id,
-            "job_id": job1.id,
-            "wps_identifier": "gmpe",
-            "input_value": "Abrahamson",
-        }
-    ]
+    expected = {
+        "id": literal_input1.id,
+        "job_id": job1.id,
+        "wps_identifier": "gmpe",
+        "input_value": "Abrahamson",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_literal_input_list_101(session, client):
@@ -145,12 +157,15 @@ def test_read_literal_input_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/literal-inputs/{literal_input.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": literal_input.id,
         "job_id": job.id,
         "wps_identifier": "gmpe",
         "input_value": "Abrahamson",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_literal_input_detail_none(client):

--- a/backend/tests/test_routes/test_order_job_refs.py
+++ b/backend/tests/test_routes/test_order_job_refs.py
@@ -22,13 +22,16 @@ def test_read_order_job_ref_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/order-job-refs")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": order_job_ref.id,
-            "order_id": order.id,
-            "job_id": job.id,
-        }
-    ]
+    expected = {
+        "id": order_job_ref.id,
+        "order_id": order.id,
+        "job_id": job.id,
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_order_job_ref_list_filter_job_id(session, client):
@@ -45,13 +48,16 @@ def test_read_order_job_ref_list_filter_job_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/order-job-refs?job_id={job1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": order_job_ref1.id,
-            "order_id": order.id,
-            "job_id": job1.id,
-        }
-    ]
+    expected = {
+        "id": order_job_ref1.id,
+        "order_id": order.id,
+        "job_id": job1.id,
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_order_job_ref_list_filter_order_id(session, client):
@@ -70,13 +76,16 @@ def test_read_order_job_ref_list_filter_order_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/order-job-refs?order_id={order1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": order_job_ref1.id,
-            "order_id": order1.id,
-            "job_id": job1.id,
-        }
-    ]
+    expected = {
+        "id": order_job_ref1.id,
+        "order_id": order1.id,
+        "job_id": job1.id,
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_order_job_ref_list_101(session, client):
@@ -113,11 +122,14 @@ def test_read_order_job_ref_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/order-job-refs/{order_job_ref.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": order_job_ref.id,
         "order_id": order.id,
         "job_id": job.id,
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_order_job_ref_detail_none(client):

--- a/backend/tests/test_routes/test_orders.py
+++ b/backend/tests/test_routes/test_orders.py
@@ -17,13 +17,16 @@ def test_read_order_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/orders")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": order.id,
-            "user_id": user.id,
-            "order_constraints": {},
-        }
-    ]
+    expected = {
+        "id": order.id,
+        "user_id": user.id,
+        "order_constraints": {},
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_order_list_filter_user_id(session, client):
@@ -40,13 +43,16 @@ def test_read_order_list_filter_user_id(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/orders?user_id={user1.id}")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": order1.id,
-            "user_id": user1.id,
-            "order_constraints": {"gmpe": ["Abrahamson"]},
-        }
-    ]
+    expected = {
+        "id": order1.id,
+        "user_id": user1.id,
+        "order_constraints": {"gmpe": ["Abrahamson"]},
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_order_list_101(session, client):
@@ -78,11 +84,14 @@ def test_read_order_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/orders/{order.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": order.id,
         "user_id": user.id,
         "order_constraints": {"gmpe": ["Abrahamson"]},
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_order_detail_none(client):

--- a/backend/tests/test_routes/test_processes.py
+++ b/backend/tests/test_routes/test_processes.py
@@ -18,13 +18,16 @@ def test_read_process_list_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/processes")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": process.id,
-            "wps_url": "https://rz-vm140.gfz-potsdam.de",
-            "wps_identifier": "shakyground",
-        }
-    ]
+    expected = {
+        "id": process.id,
+        "wps_url": "https://rz-vm140.gfz-potsdam.de",
+        "wps_identifier": "shakyground",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_process_list_filter_wps_identifier(session, client):
@@ -36,13 +39,16 @@ def test_read_process_list_filter_wps_identifier(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/processes?wps_identifier=shakyground")
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": process1.id,
-            "wps_url": "https://rz-vm140.gfz-potsdam.de",
-            "wps_identifier": "shakyground",
-        }
-    ]
+    expected = {
+        "id": process1.id,
+        "wps_url": "https://rz-vm140.gfz-potsdam.de",
+        "wps_identifier": "shakyground",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_process_list_filter_wps_url(session, client):
@@ -59,13 +65,16 @@ def test_read_process_list_filter_wps_url(session, client):
         },
     )
     assert response.status_code == 200
-    assert response.json() == [
-        {
-            "id": process1.id,
-            "wps_url": "https://rz-vm140.gfz-potsdam.de",
-            "wps_identifier": "shakyground",
-        }
-    ]
+    expected = {
+        "id": process1.id,
+        "wps_url": "https://rz-vm140.gfz-potsdam.de",
+        "wps_identifier": "shakyground",
+    }
+
+    assert len(response.json()) == 1
+    for key, value in expected.items():
+        assert response.json()[0][key] == value
+    assert "created_at" in response.json()[0].keys()
 
 
 def test_read_process_list_101(session, client):
@@ -93,11 +102,14 @@ def test_read_process_detail_one(session, client):
     session.commit()
     response = client.get(f"{config.root_path}/processes/{process.id}")
     assert response.status_code == 200
-    assert response.json() == {
+    expected = {
         "id": process.id,
         "wps_url": "https://rz-vm140.gfz-potsdam.de",
         "wps_identifier": "shakyground",
     }
+    for key, value in expected.items():
+        assert response.json()[key] == value
+    assert "created_at" in response.json().keys()
 
 
 def test_read_process_detail_none(client):


### PR DESCRIPTION
We discussed yesterday that it could be helpful to have some more error handling support.

I think my pull request doesn't solve this exact problem, but I think it is still helpul to add the exception report in the jobs table (in case the WPS executation failed).
And I also add `created_at` fields, so that we know when the jobs/outputs where created.