### PR TITLE
improve logging for WPS process

### DIFF
--- a/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/dummy/AbstractWrapper.kt
+++ b/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/dummy/AbstractWrapper.kt
@@ -19,6 +19,7 @@ import org.n.riesgos.asyncwrapper.process.wps.WPSClientService
 import org.n.riesgos.asyncwrapper.process.wps.WPSProcess
 import org.n.riesgos.asyncwrapper.pulsar.MessageParser
 import org.n.riesgos.asyncwrapper.pulsar.PulsarPublisher
+import org.n.riesgos.asyncwrapper.utils.Version
 import org.n.riesgos.asyncwrapper.utils.retry
 import org.n52.geoprocessing.wps.client.WPSClientException
 import java.io.IOException
@@ -346,7 +347,7 @@ abstract class AbstractWrapper(val publisher : PulsarPublisher, val wpsConfigura
         val wpsProcess = retry<WPSProcess>(wpsConfiguration.retryConfiguration.maxRetries, wpsConfiguration.retryConfiguration.backoffMillis, { ex -> ex is WPSClientException }) {
             LOGGER.info("retrieve getCapabilities document from  ${wpsConfiguration.wpsURL} (retries: $it)")
             val wpsClientService = WPSClientService(wpsConfiguration)
-            val wpsProcess = WPSProcess(wpsClientService.establishWPSConnection(), getWpsUrl(), getWpsIdentifier(), wpsConfiguration.wpsVersion, getWpsDialect(), getRequestedOutputs(),wpsConfiguration.retryConfiguration)
+            val wpsProcess = WPSProcess(wpsClientService.establishWPSConnection(), getWpsUrl(), getWpsIdentifier(), Version(wpsConfiguration.wpsVersion), getWpsDialect(), getRequestedOutputs(),wpsConfiguration.retryConfiguration)
             LOGGER.info("retrieved getCapabilities document from ${wpsConfiguration.wpsURL} (retries: $it)")
             return@retry wpsProcess
         }

--- a/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/utils/Version.kt
+++ b/asyncwrapper/src/main/kotlin/org/n/riesgos/asyncwrapper/utils/Version.kt
@@ -1,0 +1,27 @@
+package org.n.riesgos.asyncwrapper.utils
+
+
+class Version(val versionStr : String) : Comparable<Version> {
+
+    override fun compareTo(other: Version): Int {
+        if (other == null) return 1
+        val thisParts: List<String> = this.versionStr.split(".")
+        val thatParts: List<String> = other.versionStr.split(".")
+        val length = thisParts.size.coerceAtLeast(thatParts.size)
+        for (i in 0 until length) {
+            val thisPart = if (i < thisParts.size) thisParts[i].toInt() else 0
+            val thatPart = if (i < thatParts.size) thatParts[i].toInt() else 0
+            if (thisPart < thatPart) return -1
+            if (thisPart > thatPart) return 1
+        }
+        return 0
+    }
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is Version){
+            (this.compareTo(other) == 0)
+        }else{
+            false;
+        }
+    }
+}

--- a/asyncwrapper/src/test/kotlin/org/n/riesgos/asyncwrapper/utils/VersionTest.kt
+++ b/asyncwrapper/src/test/kotlin/org/n/riesgos/asyncwrapper/utils/VersionTest.kt
@@ -1,0 +1,18 @@
+package org.n.riesgos.asyncwrapper.utils
+
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+
+internal class VersionTest {
+
+    @Test
+    fun compareTo() {
+        val one = Version("1.0.0")
+        val oneOther = Version("1.0.0")
+        val two = Version("2.0.0")
+        assertTrue(one < two)
+        assertTrue(one == oneOther)
+        assertTrue(two > one)
+    }
+}


### PR DESCRIPTION
slightly improved logging for wps process

- use request encoder depending on wps version
- log exception that caused retry

hopefully helps us to find the reason for #98 